### PR TITLE
Add permit fees and extension functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,29 @@
 A blockchain-based building permit system that allows:
 
 - Property owners to submit building permit applications
+- Payment of permit fees in STX tokens
+- Permit extensions with additional fees
 - Administrators to approve or reject permit applications
 - Transparent tracking of permit status
 - Immutable record of all permit applications and decisions
 - Verification of permit validity
 
 The system provides a decentralized and transparent way to manage construction permits, reducing fraud and improving efficiency in the construction approval process.
+
+## Features
+
+### Fee Management
+- Base permit application fee required for approval
+- Extension fees for prolonging permit validity
+- All fees paid in STX tokens directly to contract owner
+
+### Permit Extensions
+- Permits can be extended up to 2 times
+- Each extension requires additional fee payment
+- Extension updates permit expiry date
+- Transparent tracking of extension history
+
+### Status Tracking
+- PENDING: Initial state after application
+- APPROVED: After admin approval and fee payment
+- REJECTED: If application is denied

--- a/contracts/building-permit.clar
+++ b/contracts/building-permit.clar
@@ -4,11 +4,13 @@
     {
         owner: principal,
         status: (string-ascii 20),
-        property-address: (string-ascii 100),
+        property-address: (string-ascii 100), 
         permit-type: (string-ascii 50),
         issue-date: uint,
         expiry-date: uint,
-        approved-by: (optional principal)
+        approved-by: (optional principal),
+        fees-paid: uint,
+        extension-count: uint
     }
 )
 
@@ -18,9 +20,14 @@
 (define-constant err-not-found (err u101))
 (define-constant err-unauthorized (err u102))
 (define-constant err-invalid-status (err u103))
+(define-constant err-insufficient-fees (err u104))
+(define-constant err-max-extensions (err u105))
 
 ;; Data vars
 (define-data-var permit-nonce uint u0)
+(define-data-var base-permit-fee uint u100)
+(define-data-var extension-fee uint u50)
+(define-data-var max-extensions uint u2)
 
 ;; Private functions
 (define-private (is-admin (caller principal))
@@ -46,11 +53,61 @@
                 permit-type: permit-type,
                 issue-date: block-height,
                 expiry-date: expiry-date,
-                approved-by: none
+                approved-by: none,
+                fees-paid: u0,
+                extension-count: u0
             }
         ))
         (var-set permit-nonce permit-id)
         (ok permit-id)
+    )
+)
+
+(define-public (pay-permit-fees (permit-id uint))
+    (let
+        (
+            (permit (unwrap! (map-get? permits { permit-id: permit-id }) err-not-found))
+            (fee (var-get base-permit-fee))
+        )
+        (if (is-eq (get owner permit) tx-sender)
+            (begin
+                (try! (stx-transfer? fee tx-sender contract-owner))
+                (try! (map-set permits
+                    { permit-id: permit-id }
+                    (merge permit {
+                        fees-paid: fee
+                    })
+                ))
+                (ok true)
+            )
+            err-unauthorized
+        )
+    )
+)
+
+(define-public (extend-permit (permit-id uint) (new-expiry uint))
+    (let
+        (
+            (permit (unwrap! (map-get? permits { permit-id: permit-id }) err-not-found))
+            (current-extensions (get extension-count permit))
+        )
+        (if (> current-extensions (var-get max-extensions))
+            err-max-extensions
+            (if (is-eq (get owner permit) tx-sender)
+                (begin
+                    (try! (stx-transfer? (var-get extension-fee) tx-sender contract-owner))
+                    (try! (map-set permits
+                        { permit-id: permit-id }
+                        (merge permit {
+                            expiry-date: new-expiry,
+                            extension-count: (+ current-extensions u1)
+                        })
+                    ))
+                    (ok true)
+                )
+                err-unauthorized
+            )
+        )
     )
 )
 
@@ -59,7 +116,7 @@
         (
             (permit (unwrap! (map-get? permits { permit-id: permit-id }) err-not-found))
         )
-        (if (is-admin tx-sender)
+        (if (and (is-admin tx-sender) (>= (get fees-paid permit) (var-get base-permit-fee)))
             (begin
                 (try! (map-set permits
                     { permit-id: permit-id }

--- a/tests/building-permit_test.ts
+++ b/tests/building-permit_test.ts
@@ -1,26 +1,97 @@
-
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import {
+    Clarinet,
+    Tx,
+    Chain,
+    Account,
+    types
+} from 'https://deno.land/x/clarinet@v1.0.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({
-    name: "Ensure that <...>",
+    name: "Can submit permit application",
     async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const user1 = accounts.get('wallet_1')!;
+        
         let block = chain.mineBlock([
-            /* 
-             * Add transactions with: 
-             * Tx.contractCall(...)
-            */
+            Tx.contractCall('building-permit', 'submit-permit-application', [
+                types.ascii("123 Main St"),
+                types.ascii("RESIDENTIAL_NEW"),
+                types.uint(100)
+            ], user1.address)
         ]);
-        assertEquals(block.receipts.length, 0);
-        assertEquals(block.height, 2);
+        
+        block.receipts[0].result.expectOk().expectUint(1);
+    }
+});
 
-        block = chain.mineBlock([
-            /* 
-             * Add transactions with: 
-             * Tx.contractCall(...)
-            */
+Clarinet.test({
+    name: "Can pay permit fees",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const user1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('building-permit', 'submit-permit-application', [
+                types.ascii("123 Main St"),
+                types.ascii("RESIDENTIAL_NEW"),
+                types.uint(100)
+            ], user1.address),
+            Tx.contractCall('building-permit', 'pay-permit-fees', [
+                types.uint(1)
+            ], user1.address)
         ]);
-        assertEquals(block.receipts.length, 0);
-        assertEquals(block.height, 3);
-    },
+        
+        block.receipts[1].result.expectOk().expectBool(true);
+    }
+});
+
+Clarinet.test({
+    name: "Can extend permit",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const user1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('building-permit', 'submit-permit-application', [
+                types.ascii("123 Main St"),
+                types.ascii("RESIDENTIAL_NEW"),
+                types.uint(100)
+            ], user1.address),
+            Tx.contractCall('building-permit', 'extend-permit', [
+                types.uint(1),
+                types.uint(200)
+            ], user1.address)
+        ]);
+        
+        block.receipts[1].result.expectOk().expectBool(true);
+    }
+});
+
+Clarinet.test({
+    name: "Only admin can approve permits with paid fees",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const user1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('building-permit', 'submit-permit-application', [
+                types.ascii("123 Main St"),
+                types.ascii("RESIDENTIAL_NEW"),
+                types.uint(100)
+            ], user1.address),
+            Tx.contractCall('building-permit', 'pay-permit-fees', [
+                types.uint(1)
+            ], user1.address),
+            Tx.contractCall('building-permit', 'approve-permit', [
+                types.uint(1)
+            ], deployer.address),
+            Tx.contractCall('building-permit', 'approve-permit', [
+                types.uint(1)
+            ], user1.address)
+        ]);
+        
+        block.receipts[2].result.expectOk().expectBool(true);
+        block.receipts[3].result.expectErr().expectUint(102);
+    }
 });


### PR DESCRIPTION
This PR introduces two major enhancements to the building permit system:

1. Permit Fee System
- Implements required base permit fee payment
- Fees must be paid before permit can be approved
- All fees are paid in STX tokens
- Fees are transferred directly to contract owner

2. Permit Extensions
- Allows permit holders to extend their permits
- Maximum of 2 extensions per permit
- Each extension requires additional fee payment
- Maintains count of extensions used
- Updates permit expiry date

Technical Changes:
- Added new fields to permit data structure: fees_paid and extension_count
- New constants for fee amounts and maximum extensions
- New public functions for fee payment and permit extension
- Additional validation in approve-permit to check fee payment
- Comprehensive test coverage for new functionality

Benefits:
- Creates sustainable revenue model for permit system
- Provides flexibility for permit holders through extensions
- Maintains control through extension limits
- Improves permit management and tracking